### PR TITLE
Fix test failures without '.' present in '@INC'

### DIFF
--- a/t/05_load_them.t
+++ b/t/05_load_them.t
@@ -1,5 +1,4 @@
-
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 

--- a/t/07_vector.t
+++ b/t/07_vector.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all ignore_env);

--- a/t/08_cvec.t
+++ b/t/08_cvec.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all ignore_env);

--- a/t/08_filter_outliers.t
+++ b/t/08_filter_outliers.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all ignore_env);

--- a/t/09_test_importer_vars_debug.t
+++ b/t/09_test_importer_vars_debug.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all debug);
 

--- a/t/09_test_importer_vars_debug0.t
+++ b/t/09_test_importer_vars_debug0.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all debug=0);
 

--- a/t/09_test_importer_vars_debug1.t
+++ b/t/09_test_importer_vars_debug1.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all debug=1);
 

--- a/t/09_test_importer_vars_ipres.t
+++ b/t/09_test_importer_vars_ipres.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all ipres);
 

--- a/t/09_test_importer_vars_ipres1.t
+++ b/t/09_test_importer_vars_ipres1.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all ipres=1);
 

--- a/t/09_test_importer_vars_ipres2.t
+++ b/t/09_test_importer_vars_ipres2.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all ipres=2);
 

--- a/t/09_test_importer_vars_nofill.t
+++ b/t/09_test_importer_vars_nofill.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all nofill);
 

--- a/t/09_test_importer_vars_nofill0.t
+++ b/t/09_test_importer_vars_nofill0.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all nofill=0);
 

--- a/t/09_test_importer_vars_nofill1.t
+++ b/t/09_test_importer_vars_nofill1.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all nofill=1);
 

--- a/t/09_test_importer_vars_toler.t
+++ b/t/09_test_importer_vars_toler.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 
 BEGIN { $ENV{TOLER} = 1 }
 

--- a/t/09_test_importer_vars_toler1.t
+++ b/t/09_test_importer_vars_toler1.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all toler=0);
 

--- a/t/10_mean.t
+++ b/t/10_mean.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic;

--- a/t/10_median.t
+++ b/t/10_median.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all);

--- a/t/10_mode.t
+++ b/t/10_mode.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all ignore_env);

--- a/t/10_moving_average.t
+++ b/t/10_moving_average.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all nofill);

--- a/t/15_covariance.t
+++ b/t/15_covariance.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic;

--- a/t/15_variance.t
+++ b/t/15_variance.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic;

--- a/t/17_stddev.t
+++ b/t/17_stddev.t
@@ -1,5 +1,6 @@
 
-use t::locale_hack;
+
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic;

--- a/t/19_combo.t
+++ b/t/19_combo.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all);

--- a/t/20_LSF.t
+++ b/t/20_LSF.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic;

--- a/t/20_correlation.t
+++ b/t/20_correlation.t
@@ -1,5 +1,5 @@
 use strict;
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all toler=0.000_001);
 

--- a/t/25_correlate_computed.t
+++ b/t/25_correlate_computed.t
@@ -1,4 +1,4 @@
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all toler=0.05);

--- a/t/30_empty_constructor_tests.t
+++ b/t/30_empty_constructor_tests.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use Test;
 use Statistics::Basic qw(:all);
 

--- a/t/53_co_persistance.t
+++ b/t/53_co_persistance.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all ignore_env);

--- a/t/53_persistance.t
+++ b/t/53_persistance.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all);

--- a/t/54_doc_example.t
+++ b/t/54_doc_example.t
@@ -1,5 +1,5 @@
 
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
    use Statistics::Basic qw(:all);
 
    my $v1 = vector(1,2,3,4,5);

--- a/t/60_bigfloats.t
+++ b/t/60_bigfloats.t
@@ -1,4 +1,4 @@
-use t::locale_hack;
+BEGIN { require "./t/locale_hack.pm" }
 use strict;
 use Test;
 use Statistics::Basic qw(:all toler=0.000_001);

--- a/t/75_filtered_missings.t
+++ b/t/75_filtered_missings.t
@@ -1,5 +1,5 @@
+BEGIN { require "./t/locale_hack.pm" }
 
-use t::locale_hack;
 use Test;
 use Statistics::Basic qw(:all);
 

--- a/t/75_missing_correlated.t
+++ b/t/75_missing_correlated.t
@@ -1,5 +1,5 @@
+BEGIN { require "./t/locale_hack.pm" }
 
-use t::locale_hack;
 use Test;
 use Statistics::Basic qw(:all);
 


### PR DESCRIPTION
Since Perl 5.26.0, under default conditions, '.' is no longer in `@INC`

This issue is however presently hidden, as unless somebody explicitly
sets `PERL_UNSAFE_INC=0`:
- CPAN tools set `PERL_USE_UNSAFE_INC=1` when running `./Makefile.PL`
- Test::Harness sets `PERL_USE_UNSAFE_INC=1`

Its anticipated that in a future perl version, the `PERL_USE_UNSAFE_INC`
mechansim will go away, leading to these failures.

Without this patch, the issue is always visible when testing via:
```bash
  perl Makefile.PL
  make
  perl -Mblib t/foo.t
```
But is not visible with a standard
```bash
  make test
```
( A good way to see where it gets turned on automatically is put a
  throw-away test somewhere with the code:
```perl
  die "BAD PROGRAMMER, NO COOKIE" if $ENV{PERL_USE_UNSAFE_INC};
```
Then it barfs every time your toolchain hid this problem from you.

Just don't ship that in a test or you will have a bad day )