### PR TITLE
Add github actions workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,54 @@
+name: linux
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  perl:
+
+    runs-on: ubuntu-latest
+
+    env:
+       PERL_USE_UNSAFE_INC: 0
+       PERL_CARTON_PATH: $GITHUB_WORKSPACE/local
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - '5.10'
+          - '5.12'
+          - '5.14'
+          - '5.16'
+          - '5.18'
+          - '5.20'
+          - '5.22'
+          - '5.24'
+          - '5.26'
+          - '5.28'
+          - '5.30'
+          - '5.32'
+          - '5.34'
+          - '5.36'
+          - '5.38'
+
+    container:
+      image: perl:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: curl -sL https://git.io/cpm | perl - install -g --show-build-log-on-failure
+      - name: perl Makefile.PL
+        run: perl Makefile.PL
+      - name: make
+        run: make
+      - name: Run Tests
+        run: make test


### PR DESCRIPTION
In this PR, we add GitHub Actions workflow for linux perl between `5.10` and `5.38`.

motivations:
* Clarify which versions of Perl will pass the tests in future upgrades.
* Currently,  perl 5.26 or later will fails due to  `'.' is no longer in @INC` (will fixes #3, probably.)

example results here: https://github.com/yoshikazusawa/statistics--basic/actions/runs/7429500833